### PR TITLE
Displayed visitors count and downloads counts for each daatset

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -329,7 +329,7 @@ nav ul li{
   display: flex;
 
   display: none;
-  flex-direction: row;
+  flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-evenly;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
     <div class="tile-logo">
         <ion-icon name="folder-outline"></ion-icon>
     </div>
+    &nbsp&nbsp&nbsp&nbsp&nbsp
+    <h1 style="border-left: 3px black solid;" >&nbsp  Views: <span id="count">0</span> </h1>
 </section>
 
 <section class="datasets">
@@ -65,13 +67,16 @@
             </p>
             <div class="util">
                 <div class="d-logo">
-                    <button class="logo-button"><a id="d-iris" href="./datasets/Iris.csv" download="iris.csv">
+                    <button class="logo-button" onclick="downloadButtonIris()"><a id="d-iris" href="./datasets/Iris.csv" download="iris.csv">
                         <ion-icon name="download-outline"></ion-icon></a></button>
                 </div>
                 <div class="copy-link">
                     <button class="copy-button" onclick="copy('d-iris')">Copy Link</button> <!--Created copy() function takes id of anchor tag to copy its href to clipboared-->
                 </div>
             </div>
+            <p>
+                Downloads: <span id="iris-downloads" >0</span>
+            </p>
         </div>
 
         <div class="card beginner-db">
@@ -80,13 +85,16 @@
             </p>
                 <div class="util">
                     <div class="d-logo">
-                        <button class="logo-button"><a id="d-titanic" href="./datasets/titanic.csv" download="Titanic.csv">
+                        <button class="logo-button" onclick="downloadButtonTitanic()"><a id="d-titanic" href="./datasets/titanic.csv" download="Titanic.csv">
                             <ion-icon name="download-outline"></ion-icon></a></button>
                     </div>
                     <div class="copy-link">
                         <button class="copy-button" onclick="copy('d-titanic')">Copy Link</button>
                     </div>
                 </div>
+                <p>
+                    Downloads: <span id="titanic-downloads">0</span>
+                </p>
         </div>
 
 
@@ -96,13 +104,16 @@
             </p>
                 <div class="util">
                     <div class="d-logo">
-                        <button class="logo-button"><a id="d-weather-history" href="./datasets/weatherHistory.xlsx" download="weatherHistory.xlsx">
+                        <button class="logo-button"  onclick="downloadButtonWeatherHistory()"><a id="d-weather-history" href="./datasets/weatherHistory.xlsx" download="weatherHistory.xlsx">
                             <ion-icon name="download-outline"></ion-icon></a></button>
                     </div>
                     <div class="copy-link">
                         <button class="copy-button" onclick="copy('d-weather-history')">Copy Link</button>
                     </div>
                 </div>
+                <p>
+                    Downloads: <span id="weather-history-downloads" >0</span>
+                </p>
         </div>
 
         <div class="card beginner-d">
@@ -111,13 +122,16 @@
             </p>
                 <div class="util">
                     <div class="d-logo">
-                        <button class="logo-button"><a id="d-Ads-Click-through-Rate" href="./datasets/Ads_CTR_Optimisation.csv" download="Ads_CTR_Optimisation.csv">
+                        <button class="logo-button" onclick="downloadButtonAdsClick()" ><a id="d-Ads-Click-through-Rate" href="./datasets/Ads_CTR_Optimisation.csv" download="Ads_CTR_Optimisation.csv">
                             <ion-icon name="download-outline"></ion-icon></a></button>
                     </div>
                     <div class="copy-link">
                         <button class="copy-button" onclick="copy('d-Ads-Click-through-Rate')">Copy Link</button>
                     </div>
                 </div>
+                <p>
+                    Downloads: <span id="ads-click-downloads" >0</span>
+                </p>
         </div>
 
         <div class="card beginner-d">
@@ -126,13 +140,16 @@
             </p>
                 <div class="util">
                     <div class="d-logo">
-                        <button class="logo-button"><a id="d-Reddit-Vaccine-Myths" href="./datasets/reddit_vm.csv" download="reddit_vm.csv">
+                        <button class="logo-button" onclick="downloadButtonRedditVaccineMyths()"><a id="d-Reddit-Vaccine-Myths" href="./datasets/reddit_vm.csv" download="reddit_vm.csv">
                             <ion-icon name="download-outline"></ion-icon></a></button>
                     </div>
                     <div class="copy-link">
                         <button class="copy-button" onclick="copy('d-Ads-Click-through-Rate')">Copy Link</button>
                     </div>
                 </div>
+                <p>
+                    Downloads: <span id="reddit-vaccine-downloads" >0</span>
+                </p>
         </div>
 
 
@@ -142,13 +159,16 @@
             </p>
                 <div class="util">
                     <div class="d-logo">
-                        <button class="logo-button"><a id="d-Twitch Data" href="./datasets/twitchdata-update.csv" download="twitchdata-update.csv">
+                        <button class="logo-button" onclick="downloadButtonTwitchData()"><a id="d-Twitch Data" href="./datasets/twitchdata-update.csv" download="twitchdata-update.csv">
                             <ion-icon name="download-outline"></ion-icon></a></button>
                     </div>
                     <div class="copy-link">
                         <button class="copy-button" onclick="copy('d-twitchdata-update')">Copy Link</button>
                     </div>
                 </div>
+                <p>
+                    Downloads: <span id="twitch-data-downloads" >0</span>
+                </p>
         </div>
 
         <div class="card beginner-db">
@@ -157,13 +177,16 @@
             </p>
             <div class="util">
                 <div class="d-logo">
-                    <button class="logo-button"><a id="d-movies" href="./datasets/MoviesDataset.csv" download="MoviesDataset.csv">
+                    <button class="logo-button" onclick="downloadButtonMovies()"><a id="d-movies" href="./datasets/MoviesDataset.csv" download="MoviesDataset.csv">
                         <ion-icon name="download-outline"></ion-icon></a></button>
                 </div>
                 <div class="copy-link">
                     <button class="copy-button" onclick="copy('d-movies')">Copy Link</button> 
                 </div>
             </div>
+            <p>
+                Downloads: <span id="movies-downloads" >0</span>
+            </p>
 
         </div>
 

--- a/script/script.js
+++ b/script/script.js
@@ -66,3 +66,78 @@ function copy(id) {
   Url = document.getElementById(id).href
   navigator.clipboard.writeText(Url)
 }
+
+
+
+
+
+        // functions to display number of downloads for each dataset
+        function downloadButtonIris(){
+          var counter = document.getElementById('iris-downloads');
+          console.log(counter.innerHTML);
+          localStorage.setItem('iris', parseInt(counter.innerHTML) + 1);
+          counter.innerHTML = localStorage.getItem('iris');
+      }
+      function downloadButtonTitanic(){
+          var counter = document.getElementById('titanic-downloads');
+          console.log(counter.innerHTML);
+          localStorage.setItem('titanic', parseInt(counter.innerHTML) + 1);
+          counter.innerHTML = localStorage.getItem('titanic');
+      }
+      function downloadButtonWeatherHistory(){
+          console.log("cndjcb");
+          var counter = document.getElementById('weather-history-downloads');
+          localStorage.setItem('weather-history', parseInt(counter.innerHTML) + 1);
+          counter.innerHTML = localStorage.getItem('weather-history');
+      }
+      function downloadButtonAdsClick(){
+          var counter = document.getElementById('ads-click-downloads');
+          console.log(counter.innerHTML);
+          localStorage.setItem('ads-click', parseInt(counter.innerHTML) + 1);
+          counter.innerHTML = localStorage.getItem('ads-click');
+      }
+      function downloadButtonRedditVaccineMyths(){
+        var counter = document.getElementById('reddit-vaccine-downloads');
+        console.log(counter.innerHTML);
+        localStorage.setItem('reddit-vaccine', parseInt(counter.innerHTML) + 1);
+        counter.innerHTML = localStorage.getItem('reddit-vaccine');
+      }
+      function downloadButtonTwitchData(){
+        var counter = document.getElementById('twitch-data-downloads');
+        console.log(counter.innerHTML);
+        localStorage.setItem('twitch-data', parseInt(counter.innerHTML) + 1);
+        counter.innerHTML = localStorage.getItem('twitch-data');
+      }
+      function downloadButtonMovies(){
+        var counter = document.getElementById('movies-downloads');
+        console.log(counter.innerHTML);
+        localStorage.setItem('movies', parseInt(counter.innerHTML) + 1);
+        counter.innerHTML = localStorage.getItem('movies');
+      }
+
+      // retain number of downloads on page refresh
+      window.onload = function(){
+          document.getElementById('ads-click-downloads').innerHTML = localStorage.getItem('ads-click')
+          document.getElementById('weather-history-downloads').innerHTML = localStorage.getItem('weather-history')
+          document.getElementById('iris-downloads').innerHTML = localStorage.getItem('iris')
+          document.getElementById('titanic-downloads').innerHTML = localStorage.getItem('titanic')
+          document.getElementById('reddit-vaccine-downloads').innerHTML = localStorage.getItem('reddit-vaccine')
+          document.getElementById('twitch-data-downloads').innerHTML = localStorage.getItem('twitch-data')
+          document.getElementById('movies-downloads').innerHTML = localStorage.getItem('movies')
+
+      }
+
+
+      // function to track visitors count
+      const countEl = document.getElementById('count');
+
+      updateVisitCount();
+
+      function updateVisitCount() {
+          fetch('https://api.countapi.xyz/update/data4all-karishmav/karishmavanwari/?amount=1')
+          .then(res => res.json())
+          .then(res => {
+              document.getElementById('count').innerHTML = res.value;
+          })
+      }
+


### PR DESCRIPTION
# Description

The website did not have visitor count and downloads count. I made the changes and now it shows the visitiors count next to dataset heading. Also, now the download count for each dataset is shown.


Fixes #8 
<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] New feature (non-breaking change which adds functionality)

 
# Checklist:
<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
# ATTACH SCREEN-SHOTS
![screencapture-127-0-0-1-5500-index-html-2021-10-02-20_53_12](https://user-images.githubusercontent.com/78212650/135722982-bc7ef751-7a59-4192-ab1a-f418b62f4ed3.png)

