### PR TITLE
Made copied button stable

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -235,6 +235,7 @@ ul li::before {
   cursor: pointer;
   display: block;
   padding: 0.4rem;
+  width: 72.1px;
   border: none;
   border-radius: 0.3em;
   background-color: var(--clr-accent);

--- a/script/script.js
+++ b/script/script.js
@@ -74,7 +74,7 @@ click.forEach((e)=>{
     return function() {
       if (!clicked) {
         var change = this.innerHTML;
-        this.innerHTML = "copied";
+        this.innerHTML = "copied!";
         clicked = true;
         setTimeout(function() {
           this.innerHTML = change;


### PR DESCRIPTION
## Problem: When we clicked the copy button its inner text converted to copied but this change was displacing even the other parts also like the download button's position was shifting on clicking the button. (Image Linked)
![before](https://user-images.githubusercontent.com/79038241/136657103-dd50a58a-a249-4502-a818-75421f330836.png)

## After doing slight changes in CSS these buttons are stable now. (Image Linked).
![after](https://user-images.githubusercontent.com/79038241/136657148-c94bc1da-0c76-4daf-be10-15a4f48212bf.png)




 
# Checklist:
<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

